### PR TITLE
Updating Swift version to 5.0

### DIFF
--- a/SKTCapture.podspec
+++ b/SKTCapture.podspec
@@ -8,13 +8,13 @@ Pod::Spec.new do |s|
   s.author       = { "Socket" => "developers@socketmobile.com" }
   s.documentation_url   = "https://docs.socketmobile.com/capture/ios/en/latest/"
   s.platform     = :ios, "9.1"
-  s.swift_version = '4.0'
+  s.swift_version = '5.0'
   s.source       = {
       :git => "https://github.com/SocketMobile/cocoapods-capture.git",
       :tag => "1.2.36"
   }
   s.ios.deployment_target = "9.1"
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0', 'SWIFT_OPTIMIZATION_LEVEL' => '-Owholemodule' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0', 'SWIFT_OPTIMIZATION_LEVEL' => '-Owholemodule' }
   s.source_files  = "**/*.{h,swift}"
   s.public_header_files = "*.h"
   s.preserve_path = "**/*.a"


### PR DESCRIPTION
Removes warning about migration required due to this. No code changes needed.